### PR TITLE
Update NovaTinyMCE.php

### DIFF
--- a/src/NovaTinyMCE.php
+++ b/src/NovaTinyMCE.php
@@ -18,7 +18,7 @@ class NovaTinyMCE extends Field
      */
     public $component = 'Nova-TinyMCE';
 
-    public function __construct(string $name, ?string $attribute = null, ?mixed $resolveCallback = null)
+    public function __construct(string $name, ?string $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 


### PR DESCRIPTION
When passing closure to modify the default field value with Nova 3.x + Laravel 7 + PHP 7.4 using ?mixed will throw error:

\NovaTinyMCE::__construct() must be an instance of Emilianotisato\NovaTinyMCE\mixed or null, instance of Closure given, called in .../vendor/laravel/nova/src/Makeable.php on line 14