### PR TITLE
Add help texts to FormField.vue

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,5 +1,5 @@
 <template>
-    <default-field :field="field" :full-width-content="true">
+    <default-field :field="field" :full-width-content="true" :show-help-text="showHelpText">
         <template slot="field">
             <editor :id="field.id || field.attribute"
                     v-model="value"


### PR DESCRIPTION
The help texts are not shown. I am not very up to speed with vue, but I think this will fix it